### PR TITLE
Add missing 'of'

### DIFF
--- a/content/how-it-works/_index.md
+++ b/content/how-it-works/_index.md
@@ -81,7 +81,7 @@ replica path.
 
 The time to restore a database from backup is directly related to the number and
 size of WAL files since the snapshot. To avoid having the WAL files grow without
-bound, Litestream performs new snapshots the data periodically and removes old
+bound, Litestream performs new snapshots of the data periodically and removes old
 WAL files.
 
 This process is broken up into two steps. First, a snapshot interval is set to


### PR DESCRIPTION
The sentence didn't read well. Adding an 'of' makes it better
```diff
- Litestream performs new snapshots the data periodically and removes old WAL files.
+ Litestream performs new snapshots of the data periodically and removes old WAL files.
```

Though other alternatives are:
```diff
+ Litestream snapshots the data periodically and removes old WAL files.
```
```diff
+ Litestream performs new snapshots periodically and removes old WAL files.
```